### PR TITLE
Removing the master/slave terminology

### DIFF
--- a/tencentcloud/batch/v20170312/models.py
+++ b/tencentcloud/batch/v20170312/models.py
@@ -2633,7 +2633,7 @@ class OutputMappingConfig(AbstractModel):
 
 
 class Placement(AbstractModel):
-    """Describes the location of an instance, including its availability zone, project, host (for CDH products only), master host IP, etc.
+    """Describes the location of an instance, including its availability zone, project, host (for CDH products only), main host IP, etc.
 
     """
 
@@ -2645,7 +2645,7 @@ class Placement(AbstractModel):
         :type ProjectId: int
         :param HostIds: ID list of CDHs from which the instance can be created. If you have purchased CDHs and specify this parameter, the instances you purchase will be randomly deployed on the CDHs.
         :type HostIds: list of str
-        :param HostIps: Master host IP used to create the CVM
+        :param HostIps: Main host IP used to create the CVM
         :type HostIps: list of str
         """
         self.Zone = None

--- a/tencentcloud/cvm/v20170312/models.py
+++ b/tencentcloud/cvm/v20170312/models.py
@@ -3121,7 +3121,7 @@ class OsVersion(AbstractModel):
 
 
 class Placement(AbstractModel):
-    """Describes the location of an instance, including its availability zone, project, host (for CDH products only), master host IP, etc.
+    """Describes the location of an instance, including its availability zone, project, host (for CDH products only), main host IP, etc.
 
     """
 
@@ -3133,7 +3133,7 @@ class Placement(AbstractModel):
         :type ProjectId: int
         :param HostIds: ID list of CDHs from which the instance can be created. If you have purchased CDHs and specify this parameter, the instances you purchase will be randomly deployed on the CDHs.
         :type HostIds: list of str
-        :param HostIps: Master host IP used to create the CVM
+        :param HostIps: Main host IP used to create the CVM
         :type HostIps: list of str
         """
         self.Zone = None

--- a/tencentcloud/gme/v20180711/gme_client.py
+++ b/tencentcloud/gme/v20180711/gme_client.py
@@ -82,7 +82,7 @@ class GmeClient(AbstractClient):
 
 
     def ModifyAppStatus(self, request):
-        """This API is used to change the status of an application's master switch.
+        """This API is used to change the status of an application's main switch.
 
         :param request: Request instance for ModifyAppStatus.
         :type request: :class:`tencentcloud.gme.v20180711.models.ModifyAppStatusRequest`

--- a/tencentcloud/redis/v20180412/models.py
+++ b/tencentcloud/redis/v20180412/models.py
@@ -35,7 +35,7 @@ Note: This field may return null, indicating that no valid values can be obtaine
         :param Privilege: Read/write policy. r: read-only; w: write-only; rw: read/write
 Note: This field may return null, indicating that no valid values can be obtained.
         :type Privilege: str
-        :param ReadonlyPolicy: Routing policy. master: master node; replication: slave node
+        :param ReadonlyPolicy: Routing policy. main: main node; replication: subordinate node
 Note: This field may return null, indicating that no valid values can be obtained.
         :type ReadonlyPolicy: list of str
         :param Status: Sub-account status. 1: account is being changed; 2: account is valid; -4: account has been deleted
@@ -235,7 +235,7 @@ class CreateInstanceAccountRequest(AbstractModel):
         :type AccountName: str
         :param AccountPassword: Sub-account password
         :type AccountPassword: str
-        :param ReadonlyPolicy: Routing policy. Enter `master` for master node or `replication` for slave node
+        :param ReadonlyPolicy: Routing policy. Enter `main` for main node or `replication` for subordinate node
         :type ReadonlyPolicy: list of str
         :param Privilege: Read/write policy. Enter `r` for read-only, `w` for write-only, or `rw` for read/write
         :type Privilege: str
@@ -289,7 +289,7 @@ class CreateInstancesRequest(AbstractModel):
         """
         :param ZoneId: ID of the AZ where the instance resides
         :type ZoneId: int
-        :param TypeId: Instance type. 2: Redis 2.8 master-slave edition; 3: Redis 3.2 master-slave edition (CKV master-slave edition); 4: Redis 3.2 cluster edition (CKV cluster edition); 5: Redis 2.8 standalone edition; 6: Redis 4.0 master-slave edition; 7: Redis 4.0 cluster edition
+        :param TypeId: Instance type. 2: Redis 2.8 main-subordinate edition; 3: Redis 3.2 main-subordinate edition (CKV main-subordinate edition); 4: Redis 3.2 cluster edition (CKV cluster edition); 5: Redis 2.8 standalone edition; 6: Redis 4.0 main-subordinate edition; 7: Redis 4.0 cluster edition
         :type TypeId: int
         :param MemSize: Instance capacity in MB. The actual value is subject to the specifications returned by the purchasable specification querying API |
         :type MemSize: int
@@ -313,11 +313,11 @@ class CreateInstancesRequest(AbstractModel):
         :type SecurityGroupIdList: list of str
         :param VPort: User-defined port. If this parameter is left blank, 6379 will be used by default
         :type VPort: int
-        :param RedisShardNum: Number of instance shards. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, Redis 2.8 standalone edition, and Redis 4.0 master-slave edition
+        :param RedisShardNum: Number of instance shards. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, Redis 2.8 standalone edition, and Redis 4.0 main-subordinate edition
         :type RedisShardNum: int
-        :param RedisReplicasNum: Number of instance replicas. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, and Redis 2.8 standalone edition
+        :param RedisReplicasNum: Number of instance replicas. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, and Redis 2.8 standalone edition
         :type RedisReplicasNum: int
-        :param ReplicasReadonly: Whether to support read-only replicas. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, and Redis 2.8 standalone edition |
+        :param ReplicasReadonly: Whether to support read-only replicas. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, and Redis 2.8 standalone edition |
         :type ReplicasReadonly: bool
         :param InstanceName: Instance name
         :type InstanceName: str
@@ -1273,16 +1273,16 @@ class DescribeInstanceShardsRequest(AbstractModel):
         """
         :param InstanceId: Instance ID
         :type InstanceId: str
-        :param FilterSlave: Whether to filter out the slave node information
-        :type FilterSlave: bool
+        :param FilterSubordinate: Whether to filter out the subordinate node information
+        :type FilterSubordinate: bool
         """
         self.InstanceId = None
-        self.FilterSlave = None
+        self.FilterSubordinate = None
 
 
     def _deserialize(self, params):
         self.InstanceId = params.get("InstanceId")
-        self.FilterSlave = params.get("FilterSlave")
+        self.FilterSubordinate = params.get("FilterSubordinate")
 
 
 class DescribeInstanceShardsResponse(AbstractModel):
@@ -1350,7 +1350,7 @@ class DescribeInstancesRequest(AbstractModel):
         :type RegionIds: list of int
         :param Status: Instance status. 0: to be initialized; 1: in process; 2: running; -2: isolated; -3: to be deleted
         :type Status: list of int
-        :param TypeVersion: Type edition. 1: standalone edition; 2: master-slave edition; 3: cluster edition
+        :param TypeVersion: Type edition. 1: standalone edition; 2: main-subordinate edition; 3: cluster edition
         :type TypeVersion: int
         :param EngineName: Engine information: Redis-2.8, Redis-4.0, CKV
         :type EngineName: str
@@ -1358,7 +1358,7 @@ class DescribeInstancesRequest(AbstractModel):
         :type AutoRenew: list of int
         :param BillingMode: Billing method. postpaid: pay-as-you-go; prepaid: monthly subscription
         :type BillingMode: str
-        :param Type: Instance type. 1: legacy Redis cluster edition; 2: Redis 2.8 master-slave edition; 3: CKV master-slave edition; 4: CKV cluster edition; 5: Redis 2.8 standalone edition; 6: Redis 4.0 master-slave edition; 7: Redis 4.0 cluster edition
+        :param Type: Instance type. 1: legacy Redis cluster edition; 2: Redis 2.8 main-subordinate edition; 3: CKV main-subordinate edition; 4: CKV cluster edition; 5: Redis 2.8 standalone edition; 6: Redis 4.0 main-subordinate edition; 7: Redis 4.0 cluster edition
         :type Type: int
         :param SearchKeys: Search keywords, which can be instance ID, instance name, or complete IP
         :type SearchKeys: list of str
@@ -1840,7 +1840,7 @@ class EnableReplicaReadonlyRequest(AbstractModel):
         """
         :param InstanceId: Serial ID of an instance
         :type InstanceId: str
-        :param ReadonlyPolicy: Account routing policy. If `master` or `replication` is entered, it means to route to the master or slave node; if this is left blank, it means to write into the master node and read from the slave node by default
+        :param ReadonlyPolicy: Account routing policy. If `main` or `replication` is entered, it means to route to the main or subordinate node; if this is left blank, it means to write into the main node and read from the subordinate node by default
         :type ReadonlyPolicy: list of str
         """
         self.InstanceId = None
@@ -1909,7 +1909,7 @@ class InstanceClusterNode(AbstractModel):
         :type Name: str
         :param RunId: ID of the runtime node of an instance
         :type RunId: str
-        :param Role: Cluster role. 0: master; 1: slave
+        :param Role: Cluster role. 0: main; 1: subordinate
         :type Role: int
         :param Status: Node status. 0: readwrite; 1: read; 2: backup
         :type Status: int
@@ -2292,7 +2292,7 @@ class InstanceSet(AbstractModel):
         :type Size: float
         :param SizeUsed: This field has been disused
         :type SizeUsed: float
-        :param Type: Instance type. 1: Redis 2.8 cluster edition; 2: Redis 2.8 master-slave edition; 3: CKV master-slave edition (Redis 3.2); 4: CKV cluster edition (Redis 3.2); 5: Redis 2.8 standalone edition; 6: Redis 4.0 master-slave edition; 7: Redis 4.0 cluster edition
+        :param Type: Instance type. 1: Redis 2.8 cluster edition; 2: Redis 2.8 main-subordinate edition; 3: CKV main-subordinate edition (Redis 3.2); 4: CKV cluster edition (Redis 3.2); 5: Redis 2.8 standalone edition; 6: Redis 4.0 main-subordinate edition; 7: Redis 4.0 cluster edition
         :type Type: int
         :param AutoRenewFlag: Whether to set the auto-renewal flag for an instance. 1: auto-renewal set; 0: auto-renewal not set
         :type AutoRenewFlag: int
@@ -2300,7 +2300,7 @@ class InstanceSet(AbstractModel):
         :type DeadlineTime: str
         :param Engine: Engine: Redis community edition, Tencent Cloud CKV
         :type Engine: str
-        :param ProductType: Product type: Redis 2.8 cluster edition, Redis 2.8 master-slave edition, Redis 3.2 master-slave edition (CKV master-slave edition), Redis 3.2 cluster edition (CKV cluster edition), Redis 2.8 standalone edition, Redis 4.0 cluster edition
+        :param ProductType: Product type: Redis 2.8 cluster edition, Redis 2.8 main-subordinate edition, Redis 3.2 main-subordinate edition (CKV main-subordinate edition), Redis 3.2 cluster edition (CKV cluster edition), Redis 2.8 standalone edition, Redis 4.0 cluster edition
         :type ProductType: str
         :param UniqVpcId: VPC ID, such as vpc-fk33jsf43kgv
         :type UniqVpcId: str
@@ -2328,8 +2328,8 @@ class InstanceSet(AbstractModel):
         :type PriceId: int
         :param CloseTime: Isolation time
         :type CloseTime: str
-        :param SlaveReadWeight: Read weight of a slave node
-        :type SlaveReadWeight: int
+        :param SubordinateReadWeight: Read weight of a subordinate node
+        :type SubordinateReadWeight: int
         :param InstanceTags: Instance tag information
 Note: This field may return null, indicating that no valid values can be obtained.
         :type InstanceTags: list of InstanceTagInfo
@@ -2372,7 +2372,7 @@ Note: This field may return null, indicating that no valid values can be obtaine
         self.RedisReplicasNum = None
         self.PriceId = None
         self.CloseTime = None
-        self.SlaveReadWeight = None
+        self.SubordinateReadWeight = None
         self.InstanceTags = None
         self.ProjectName = None
         self.NoAuth = None
@@ -2416,7 +2416,7 @@ Note: This field may return null, indicating that no valid values can be obtaine
         self.RedisReplicasNum = params.get("RedisReplicasNum")
         self.PriceId = params.get("PriceId")
         self.CloseTime = params.get("CloseTime")
-        self.SlaveReadWeight = params.get("SlaveReadWeight")
+        self.SubordinateReadWeight = params.get("SubordinateReadWeight")
         if params.get("InstanceTags") is not None:
             self.InstanceTags = []
             for item in params.get("InstanceTags"):
@@ -2687,7 +2687,7 @@ class ModifyInstanceAccountRequest(AbstractModel):
         :type AccountPassword: str
         :param Remark: Sub-account description information
         :type Remark: str
-        :param ReadonlyPolicy: Sub-account routing policy. Enter `master` to route to the master node or `slave` to route to the slave node
+        :param ReadonlyPolicy: Sub-account routing policy. Enter `main` to route to the main node or `subordinate` to route to the subordinate node
         :type ReadonlyPolicy: list of str
         :param Privilege: Sub-account read/write policy. Enter `r` for read-only, `w` for write-only, or `rw` for read/write
         :type Privilege: str
@@ -2908,9 +2908,9 @@ class ProductConf(AbstractModel):
 
     def __init__(self):
         """
-        :param Type: Product type. 2: Redis master-slave edition; 3: CKV master-slave edition; 4: CKV cluster edition; 5: Redis standalone edition; 7: Redis cluster edition
+        :param Type: Product type. 2: Redis main-subordinate edition; 3: CKV main-subordinate edition; 4: CKV cluster edition; 5: Redis standalone edition; 7: Redis cluster edition
         :type Type: int
-        :param TypeName: Product name: Redis master-slave edition, CKV master-slave edition, CKV cluster edition, Redis standalone edition, or Redis cluster edition
+        :param TypeName: Product name: Redis main-subordinate edition, CKV main-subordinate edition, CKV cluster edition, Redis standalone edition, or Redis cluster edition
         :type TypeName: str
         :param MinBuyNum: Minimum purchasable quantity
         :type MinBuyNum: int
@@ -3469,9 +3469,9 @@ class UpgradeInstanceRequest(AbstractModel):
         :type InstanceId: str
         :param MemSize: Shard size in MB
         :type MemSize: int
-        :param RedisShardNum: Number of shards. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, and Redis 2.8 standalone edition
+        :param RedisShardNum: Number of shards. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, and Redis 2.8 standalone edition
         :type RedisShardNum: int
-        :param RedisReplicasNum: Number of replicas. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, and Redis 2.8 standalone edition
+        :param RedisReplicasNum: Number of replicas. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, and Redis 2.8 standalone edition
         :type RedisReplicasNum: int
         """
         self.InstanceId = None

--- a/tencentcloud/vpc/v20170312/models.py
+++ b/tencentcloud/vpc/v20170312/models.py
@@ -6374,7 +6374,7 @@ class ModifyVpcAttributeRequest(AbstractModel):
         :type VpcName: str
         :param EnableMulticast: Whether multicast is enabled. `true`: Enabled. `false`: Off.
         :type EnableMulticast: str
-        :param DnsServers: DNS address. A maximum of 4 addresses is supported. The first one is master server by default, and the rest are slave servers.
+        :param DnsServers: DNS address. A maximum of 4 addresses is supported. The first one is main server by default, and the rest are subordinate servers.
         :type DnsServers: list of str
         :param DomainName: Domain name
         :type DomainName: str


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.